### PR TITLE
Have cpp files depend on same named include files.

### DIFF
--- a/makefile
+++ b/makefile
@@ -41,7 +41,7 @@ build_dirs = $(sort $(dir $(obj)))
 $(build_dirs):
 	mkdir -p $(build_dirs)
 
-$(BUILD_DIR)%.o: src/%.cpp
+$(BUILD_DIR)%.o: src/%.cpp src/%.h
 	$(CXX) -c $(CPPFLAGS) -Isrc -o $@ $<
 
 $(BIN_DIR)hexibit: $(obj)


### PR DESCRIPTION
I noticed that the code was not re-built if just an include file changed.

The build logic could likely be improved.  E.g. use target dependent variables and have a 'debug' target.  It would be more intuitive than setting BUILD_MODE to 'dbg'.   It would also also you to build release and debug code in one make invocation.

....
CXXFLAGS = -g3 -gdwarf2
CCFLAGS = -g3 -gdwarf2

all: executable

debug: CXXFLAGS += -DDEBUG -g
debug: CCFLAGS += -DDEBUG -g
debug: executable
....

I can work on that if you have an interest.
I'm not really a C++ programmer, so I would need to research what current best practices are.
